### PR TITLE
fix configuration group name in seafile configuration

### DIFF
--- a/templates/conf/seafile.conf
+++ b/templates/conf/seafile.conf
@@ -2,6 +2,9 @@
 # tcp port for httpserver
 port = {{ seafile_seafile_port }}
 
+[fileserver]
+port = {{ seafile_httpserver_port }}
+
 # Set maximum upload file size in MB.
 {% if not seafile_max_upload_size_enable %}#{% endif %}
 max_upload_size = {{ seafile_max_upload_size }}
@@ -9,9 +12,6 @@ max_upload_size = {{ seafile_max_upload_size }}
 # Set maximum download directory size in MB.
 {% if not seafile_max_download_dir_size_enable %}#{% endif %}
 max_download_dir_size = {{ seafile_max_download_dir_size }}
-
-[httpserver]
-port = {{ seafile_httpserver_port }}
 
 [quota]
 # default user quota in GB, integer only


### PR DESCRIPTION
Your ansible role for seafile 5 (using 5.0.4) is working great so far, thanks for that!
I just had a small problem with increasing `max_download_dir_size` to overcome seafiles default value [1].
The new group name for settings like `max_download_dir_size`, `max_upload_size` and `port` is `[fileserver]` instead of `[httpserver]`, see [2] and [3] moreover the two max_\* settings were in the `[network]` group before.

[1] https://github.com/haiwen/seafile/blob/2ba733d43a4d96666778c422285476c434e80e4f/server/http-server.c#L34
[2] http://manual.seafile.com/config/seafile-conf.html
[3] https://github.com/haiwen/seafile/blob/2ba733d43a4d96666778c422285476c434e80e4f/server/fileserver-config.c#L7
