### PR TITLE
fix init script when running MySQL on an external host

### DIFF
--- a/templates/init/seafile.conf
+++ b/templates/init/seafile.conf
@@ -2,7 +2,7 @@
 
 {% if seafile_backend == 'sqlite' %}
 start on (runlevel [2345])
-{% elif seafile_backend == 'mysql' %}
+{% elif seafile_backend == 'mysql' and (seafile_db_host == 'localhost' or seafile_db_host == '127.0.0.1' or seafile_db_host == '::1') %}
 start on (started mysql and runlevel [2345])
 {% endif %}
 stop on (runlevel [016])

--- a/templates/init/seafile.initd.Debian
+++ b/templates/init/seafile.initd.Debian
@@ -4,7 +4,7 @@
 
 ### BEGIN INIT INFO
 # Provides:          seafile-server
-# Required-Start:    $local_fs $remote_fs $network{% if seafile_backend == 'mysql' %} mysql{% endif %}
+# Required-Start:    $local_fs $remote_fs $network{% if seafile_backend == 'mysql' and (seafile_db_host == 'localhost' or seafile_db_host == '127.0.0.1' or seafile_db_host == '::1') %} mysql{% endif %}
 
 # Required-Stop:     $local_fs
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
When provisioning Seafile connecting to a MySQL backend on a machine that does not run it's own MySQL server, installing the init.d script fails.

```
TASK [ginsys.seafile : enable init services] ***********************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax 
('{{SEAFILE_INIT_SCRIPTS}}').
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
failed: [127.0.0.1] (item={u'os_family': [u'Debian', u'RedHat'], u'name': u'seafile'}) => {"failed": true, "item": {"name": "seafile", "os_family": ["Debian", "RedHat"]}, "msg": "Error when trying to enable seafile: rc=-6 Synchronizing state for seafile.service with sysvinit using update-rc.d...\nExecuting /usr/sbin/update-rc.d seafile defaults\ninsserv: Service mysql has to be enabled to start service seafile-server\ninsserv: exiting now!\nupdate-rc.d: error: insserv rejected the script header\n*** Error in `/bin/systemctl': double free or corruption (fasttop): 0x00007f0cf6dba9c0 ***\n"}
skipping: [127.0.0.1] => (item={u'os_family': [u'RedHat'], u'name': u'seahub'}) 
```

The init script for Debian required mysql to be running before starting seafile. When the MySQL server is running on an external host, there is obviously no init script for mysql on the machine running Seafile, which caused the error above.
