### PR TITLE
fix dependencies array that was interpreted as string

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
     state:      restarted
     sleep:      5
   when:         ansible_os_family in item.os_family
-  with_items:   SEAFILE_INIT_SCRIPTS
+  with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
 
 - name:         start_seafile
   service:
@@ -16,7 +16,7 @@
     state:      started
     sleep:      5
   when:         ansible_os_family in item.os_family
-  with_items:   '{{SEAFILE_INIT_SCRIPTS}}'
+  with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
 
 - name:         stop_seafile
   service:
@@ -24,5 +24,5 @@
     state:      stopped
     sleep:      5
   when:         ansible_os_family in item.os_family
-  with_items:   '{{SEAFILE_INIT_SCRIPTS}}'
+  with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
 

--- a/tasks/1_prerequisites.yml
+++ b/tasks/1_prerequisites.yml
@@ -13,20 +13,20 @@
   apt:
     name:               '{{ item }}'
     state:              latest
-  with_items:   DEPENDENCY_PACKAGES_APT
+  with_items:   '{{ DEPENDENCY_PACKAGES_APT }}'
   when:         ansible_pkg_mgr == 'apt'
 
 - name:         install dependencies - rpm + python 2.6
   yum:
     name:               '{{ item }}'
     state:              latest
-  with_items:   DEPENDENCY_PACKAGES_RPM
+  with_items:   '{{ DEPENDENCY_PACKAGES_RPM }}'
   when:         ansible_pkg_mgr == 'yum' and ansible_python_version.startswith('2.6')
 
 - name:         install dependencies - rpm + python 2.7
   yum:
     name:               '{{ item }}'
     state:              latest
-  with_items:   DEPENDENCY_PACKAGES_RPM
+  with_items:   '{{ DEPENDENCY_PACKAGES_RPM }}'
   when:         ansible_pkg_mgr == 'yum' and ansible_python_version.startswith('2.7')
 

--- a/tasks/3_download.yml
+++ b/tasks/3_download.yml
@@ -27,7 +27,7 @@
 - name:                 check if we already have init scripts
   stat:
     path:               /etc/init.d/{{ item.name }}
-  with_items:           SEAFILE_INIT_SCRIPTS
+  with_items:           '{{ SEAFILE_INIT_SCRIPTS }}'
   when:                 ansible_os_family in item.os_family
   register:             _seafile_init_script_present
 
@@ -37,8 +37,8 @@
     state:              stopped
     sleep:              5
   with_nested:
-                        - '{{SEAFILE_INIT_SCRIPTS}}'
-                        - _seafile_init_script_present.results
+                        - '{{ SEAFILE_INIT_SCRIPTS }}'
+                        - '{{ _seafile_init_script_present.results }}'
   when:
                         - ansible_os_family in item.0.os_family
                         - not item.1|skipped

--- a/tasks/9_init.yml
+++ b/tasks/9_init.yml
@@ -11,21 +11,21 @@
 
 - name:         provision sysvinit script
   template:
-    src:        init/{{ item.name }}.initd.{{ ansible_os_family }}
-    dest:       /etc/init.d/{{ item.name }}
+    src:        'init/{{ item.name }}.initd.{{ ansible_os_family }}'
+    dest:       '/etc/init.d/{{ item.name }}'
     owner:      root
     group:      root
     mode:       0750
   when:         ansible_os_family in item.os_family and ansible_service_mgr == "sysvinit"
-  with_items:   SEAFILE_INIT_SCRIPTS
+  with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
   notify:       restart_seafile
 
 - name:         provision systemd services
   template:
-    src:        systemd/{{ item.name }}.service
-    dest:       /lib/systemd/system/
+    src:        'systemd/{{ item.name }}.service'
+    dest:       '/lib/systemd/system/'
   when:         ansible_service_mgr == "systemd"
-  with_items:   SEAFILE_INIT_SCRIPTS
+  with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
   notify:
   - systemd_reload
   - restart_seafile
@@ -45,6 +45,6 @@
     name:       '{{ item.name }}'
     enabled:    yes
   when:         ansible_os_family in item.os_family
-  with_items:   SEAFILE_INIT_SCRIPTS
+  with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
   notify:       restart_seafile
 


### PR DESCRIPTION
## Error
```
TASK [ginsys.seafile : install dependencies - deb] *****************************************************************************************************************************************************************************************************************
failed: [127::1] (item=[u'DEPENDENCY_PACKAGES_APT']) => {"failed": true, "item": ["DEPENDENCY_PACKAGES_APT"], "msg": "No package matching 'DEPENDENCY_PACKAGES_APT' is available"}
	to retry, use: --limit @/Project/Ansible/seafile-test/seafile.retry
```

## Solution
`DEPENDENCY_PACKAGES_APT` in the prerequisites task was interpreted as string. With wrapping it in quotes, Ansible interprets it as variable.