### PR TITLE
Update for ansible 2.x

### DIFF
--- a/example/group_vars/seafile.yml
+++ b/example/group_vars/seafile.yml
@@ -1,6 +1,6 @@
 ---
 # version to install
-seafile_install_version:    '6.2.3'
+seafile_install_version:    '6.2.5'
 
 # names, files and directory locations
 seafile_user:               seafile

--- a/tasks/1_prerequisites.yml
+++ b/tasks/1_prerequisites.yml
@@ -3,7 +3,9 @@
   assert:
     that:
       - ansible_version is defined
-      - ansible_version.full|version_compare(min_ansible_version, '>=')
+      - ansible_version.full is version_compare(min_ansible_version, '>=')
+      # For ansible 2.5 and up:
+      #- ansible_version.full is version(min_ansible_version, '>=')
       - ansible_distribution in SEAFILE_SUPPORTED_DISTRIBUTIONS
       - '".".join(seafile_install_version.split(".")[0:2]) in SEAFILE_SUPPORTED_VERSIONS'
       - seafile_backend in SEAFILE_SUPPORTED_BACKENDS

--- a/tasks/3_download.yml
+++ b/tasks/3_download.yml
@@ -12,7 +12,7 @@
     validate_certs:     no
     dest:               '{{ seafile_org_dir + "/installed" }}'
   register:             seafile_tarball_dl
-  always_run:           true
+  check_mode:           no
 
 - name:                 untar tarball
   become:               yes
@@ -41,9 +41,9 @@
                         - '{{ _seafile_init_script_present.results }}'
   when:
                         - ansible_os_family in item.0.os_family
-                        - not item.1|skipped
+                        - not item.1 is skipped
                         - item.1.stat.exists
-                        - seafile_tarball_dl|changed or seafile_tarball_ex|changed
+                        - seafile_tarball_dl is changed or seafile_tarball_ex is changed
 
 - name: link latest release
   become:               yes

--- a/tasks/4_preconfigure.yml
+++ b/tasks/4_preconfigure.yml
@@ -13,7 +13,7 @@
   become_user:          '{{ seafile_user }}'
   shell:                grep ID {{ seafile_mylib_dir }}/ccnet/ccnet.conf | cut -d= -f2
   register:             _seafile_ccnet_ID
-  always_run:           true
+  check_mode:           no
   changed_when:         false
   failed_when:          _seafile_ccnet_ID.stdout == "" or _seafile_ccnet_ID.stderr != ""
 
@@ -43,7 +43,7 @@
   become_user:          '{{ seafile_user }}'
   command:              cat {{ seafile_mylib_dir }}/seahub_settings_secret_key
   register:             _seafile_seahub_settings_secret_key
-  always_run:           true
+  check_mode:           no
   changed_when:         false
   failed_when:          _seafile_seahub_settings_secret_key.stdout == "" or _seafile_seahub_settings_secret_key.stderr != ""
 

--- a/tasks/6_customize.yml
+++ b/tasks/6_customize.yml
@@ -14,10 +14,10 @@
   become:         false
   local_action:   command chdir="{{ seafile_custom_files_path }}" find . -mindepth 1 -type d
   changed_when:   false
-  always_run:     yes
+  check_mode:     no
   register:       seafile_custom_files_path_dirs
   when:
-  - not seafile_custom_files_folder_found|skipped
+  - not seafile_custom_files_folder_found is skipped
   - seafile_custom_files_folder_found.stat.exists
   - seafile_custom_files_folder_found.stat.isdir
 
@@ -25,10 +25,10 @@
   become:         false
   local_action:   command chdir="{{ seafile_custom_files_path }}" find . -mindepth 1 -type f
   changed_when:   false
-  always_run:     yes
+  check_mode:     no
   register:       seafile_custom_files_path_files
   when:
-  - not seafile_custom_files_folder_found|skipped
+  - not seafile_custom_files_folder_found is skipped
   - seafile_custom_files_folder_found.stat.exists
   - seafile_custom_files_folder_found.stat.isdir
 
@@ -41,7 +41,7 @@
     mode:         0755
   with_items:     '{{ seafile_custom_files_path_dirs.stdout_lines }}'
   when:
-  - not seafile_custom_files_folder_found|skipped
+  - not seafile_custom_files_folder_found is skipped
   - seafile_custom_files_folder_found.stat.exists
   - seafile_custom_files_folder_found.stat.isdir
 
@@ -54,7 +54,7 @@
     mode:         0644
   with_items:     '{{ seafile_custom_files_path_files.stdout_lines }}'
   when:
-  - not seafile_custom_files_folder_found|skipped
+  - not seafile_custom_files_folder_found is skipped
   - seafile_custom_files_folder_found.stat.exists
   - seafile_custom_files_folder_found.stat.isdir
 


### PR DESCRIPTION
Just some cosmetic changes and future-proofing, because some pipe filters throw warnings on recent versions of ansible.
I've left `version_compare` instead of `version()` because not all users are on ansible 2.5+ yet.