### PR TITLE
Update to version 6.3.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,8 @@ seafile_webdav_port:        8080
 # see https://manual.seafile.com/changelog/server-changelog.html#63
 seafile_fastcgi_enabled:    false
 seafile_fastcgi_port:       8000
+# seahub behind reverse proxy
+seafile_gunicorn_port:      '{{ seafile_fastcgi_port }}'
 
 # webdav settings
 seafile_webdav_enabled:     false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,7 +81,8 @@ seafile_ccnet_port:         10001
 seafile_seafile_port:       12001
 seafile_httpserver_port:    8082
 seafile_webdav_port:        8080
-# fastcgi
+# fastcgi is no longer supported since version 6.3
+# see https://manual.seafile.com/changelog/server-changelog.html#63
 seafile_fastcgi_enabled:    false
 seafile_fastcgi_port:       8000
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,7 +91,7 @@ seafile_gunicorn_port:      '{{ seafile_fastcgi_port }}'
 # webdav settings
 seafile_webdav_enabled:     false
 seafile_webdav_fastcgi:     false
-seafile_webdav_path:        '/'
+seafile_webdav_path:        '/dav'
 
 # seahub settings
 seafile_seahub_admin_email:     admin@{{ seafile_ip_or_domain }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # version to install
-seafile_install_version:    '6.2.3'
+seafile_install_version:    '6.3.2'
 seafile_install_version_beta: False
 
 # distribution download info

--- a/example/group_vars/seafile.yml
+++ b/example/group_vars/seafile.yml
@@ -38,7 +38,7 @@ seafile_site_root:  '/'
 seafile_cloud_mode: true
 seafile_logo_path:  'custom/ginsys_seafile_logo.png'
 
-seafile_fastcgi_enabled:    true
+seafile_fastcgi_enabled:    false
 
 # webdav settings
 seafile_webdav_enabled:     true
@@ -101,21 +101,15 @@ nginx_sites:
      ssl_certificate:        /etc/ssl/private/server.crt.pem
    location:
      - name:  /
-       fastcgi_pass:  127.0.0.1:{{ seafile_fastcgi_port }}
-       "fastcgi_param SCRIPT_FILENAME":     $document_root$fastcgi_script_name
-       "fastcgi_param PATH_INFO":           $fastcgi_script_name
-       "fastcgi_param SERVER_PROTOCOL":     $server_protocol
-       "fastcgi_param QUERY_STRING":        $query_string
-       "fastcgi_param REQUEST_METHOD":      $request_method
-       "fastcgi_param CONTENT_TYPE":        $content_type
-       "fastcgi_param CONTENT_LENGTH":      $content_length
-       "fastcgi_param SERVER_ADDR":         $server_addr
-       "fastcgi_param SERVER_PORT":         $server_port
-       "fastcgi_param SERVER_NAME":         $server_name
-       "fastcgi_param HTTPS":               on
-       "fastcgi_param HTTP_SCHEME":         https
-       access_log:    /var/log/nginx/seahub.access.log
-       error_log:     /var/log/nginx/seahub.error.log
+       proxy_pass:  127.0.0.1:{{ seafile_gunicorn_port }}
+       "proxy_set_header":    "Host $host"
+       "proxy_set_header":    "X-Real-IP $remote_addr"
+       "proxy_set_header":    "X-Forwarded-For $proxy_add_x_forwarded_for"
+       "proxy_set_header":    "X-Forwarded-Host $server_name"
+       "proxy_read_timeout":  "1200s"
+       client_max_body_size:  0
+       access_log:            /var/log/nginx/seahub.access.log
+       error_log:             /var/log/nginx/seahub.error.log
      - name: /seafhttp
        rewrite:               ^/seafhttp(.*)$ $1 break
        proxy_pass:            http://127.0.0.1:{{ seafile_httpserver_port }}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,4 +25,3 @@
     sleep:      5
   when:         ansible_os_family in item.os_family
   with_items:   '{{ SEAFILE_INIT_SCRIPTS }}'
-

--- a/tasks/1_prerequisites.yml
+++ b/tasks/1_prerequisites.yml
@@ -32,3 +32,15 @@
   with_items:   '{{ DEPENDENCY_PACKAGES_RPM }}'
   when:         ansible_pkg_mgr == 'yum' and ansible_python_version.startswith('2.7')
 
+- name:         check if deprecated features are in use
+  assert:
+    that:
+      # For ansible 2.5 and up:
+      #- 'not(seafile_fastcgi_enabled and seafile_install_version is version("6.3", ">="))'
+      - 'not(seafile_fastcgi_enabled and seafile_install_version is version_compare("6.3", ">="))'
+    msg: >
+      seafile_fastcgi_enabled is not supported since seafile version 6.3.
+      If you are using a reverse proxy, you will need to change fastcgi_pass to proxy_pass in your server configuration,
+      have a look at the example in example/group_vars/seafile.yml.
+      More information at https://manual.seafile.com/changelog/server-changelog.html#63
+      and https://manual.seafile.com/deploy/deploy_with_nginx.html

--- a/tasks/1_prerequisites.yml
+++ b/tasks/1_prerequisites.yml
@@ -15,6 +15,8 @@
   apt:
     name:               '{{ item }}'
     state:              latest
+    update_cache:       true
+    cache_valid_time:   300
   with_items:   '{{ DEPENDENCY_PACKAGES_APT }}'
   when:         ansible_pkg_mgr == 'apt'
 

--- a/tasks/3_download.yml
+++ b/tasks/3_download.yml
@@ -9,7 +9,6 @@
   become_user:          '{{ seafile_user }}'
   get_url:
     url:                '{{ seafile_tarball_url }}'
-    validate_certs:     no
     dest:               '{{ seafile_org_dir + "/installed" }}'
   register:             seafile_tarball_dl
   check_mode:           no

--- a/tasks/5_configure.yml
+++ b/tasks/5_configure.yml
@@ -20,6 +20,8 @@
       dest:             '{{ seafile_conf_dir }}/'
     - src:              'conf/seahub_settings.py'
       dest:             '{{ seafile_conf_dir }}/'
+    - src:              'conf/gunicorn.conf'
+      dest:             '{{ seafile_conf_dir }}/'
     # handy environment file to be sourced when doing things manually
     - src:              'bin/environment'
       dest:             '{{ seafile_org_dir + "/bin/" }}'

--- a/tasks/7_database.yml
+++ b/tasks/7_database.yml
@@ -2,7 +2,7 @@
 - name:                 provision database
   become:               yes
   become_user:          '{{ seafile_user }}'
-  shell:                '{{ SEAFILE_MANAGEPY }} syncdb --noinput'
+  shell:                '{{ SEAFILE_MANAGEPY }} migrate --no-input'
   environment:          '{{ SEAFILE_ENVIRONMENT }}'
   register:             seafile_syncdb
   changed_when:         seafile_syncdb.stdout.find( "Creating table ") != -1

--- a/templates/bin/init_admin.py
+++ b/templates/bin/init_admin.py
@@ -15,6 +15,7 @@ def main():
         check_init_admin.create_admin('{{ seafile_seahub_admin_email }}', '{{ seafile_seahub_admin_password }}')
     else:
         print "changed=false"
+    subprocess.call(["{{ seafile_latest_dir }}/seafile.sh", "stop"])
 
 if __name__ == '__main__':
     try:

--- a/templates/conf/gunicorn.conf
+++ b/templates/conf/gunicorn.conf
@@ -1,0 +1,21 @@
+import os
+
+daemon = True
+workers = 5
+
+# default localhost:8000
+bind = "0.0.0.0:{{ seafile_gunicorn_port }}"
+
+# Pid
+pids_dir = '{{ seafile_org_dir + "/pids" }}'
+pidfile = os.path.join(pids_dir, 'seahub.pid')
+
+# Logging
+logs_dir = '{{ seafile_log_dir }}'
+errorlog = os.path.join(logs_dir, 'gunicorn_error.log')
+accesslog = os.path.join(logs_dir, 'gunicorn_access.log')
+
+# for file upload, we need a longer timeout value (default is only 30s, too short)
+timeout = 1200
+
+limit_request_line = 8190

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,6 +10,7 @@ SEAFILE_SUPPORTED_VERSIONS:
   - '6.0'
   - '6.1'
   - '6.2'
+  - '6.3'
 SEAFILE_SUPPORTED_BACKENDS:
   - 'sqlite'
   - 'mysql'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -29,8 +29,9 @@ SEAFILE_INIT_SCRIPTS:
 DEPENDENCY_PACKAGES_APT:
 - python-setuptools
 - python-simplejson
-- python-imaging
+- python-pil
 - python-mysqldb
+- python-requests
 - sqlite
 - rsync
 - sudo


### PR DESCRIPTION
There's a new seafile version out in the wild with quite some nice changes. Django was updated and fastcgi for seahub deprecated. For more information see the [official changelog](https://manual.seafile.com/changelog/server-changelog.html#63).

I have added a check that will fail when attempting to run this playbook with `seafile_install_version` >= 6.3 and `seafile_fastcgi_enabled`.

The examples have been updated to reflect the changes as well.

The gunicorn configuration very closely resembles the default one generated by the update script, but it's templated.