### PR TITLE
Bump seafile versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # version to install
-seafile_install_version:    '6.3.2'
+seafile_install_version:    '6.3.3'
 seafile_install_version_beta: False
 
 # distribution download info

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # version to install
-seafile_install_version:    '6.3.3'
+seafile_install_version:    '6.3.4'
 seafile_install_version_beta: False
 
 # distribution download info

--- a/example/group_vars/seafile.yml
+++ b/example/group_vars/seafile.yml
@@ -1,6 +1,6 @@
 ---
 # version to install
-seafile_install_version:    '6.3.3'
+seafile_install_version:    '6.3.4'
 
 # names, files and directory locations
 seafile_user:               seafile

--- a/example/group_vars/seafile.yml
+++ b/example/group_vars/seafile.yml
@@ -1,6 +1,6 @@
 ---
 # version to install
-seafile_install_version:    '6.2.5'
+seafile_install_version:    '6.3.3'
 
 # names, files and directory locations
 seafile_user:               seafile


### PR DESCRIPTION
Running 6.3.4 successfully since forever, but I think I had migration troubles.